### PR TITLE
#55 - Add simple autoloader with static paths for classes without namespaces

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,20 @@
+<?php
+define('BASEPATH', __DIR__ . DIRECTORY_SEPARATOR);
+
+spl_autoload_register(function ($class) {
+    // Paths to autoload
+    $paths = [
+        "Classes",
+    ];
+
+    // Iterates through all paths and requires all classes of this directory
+    for ($i = 0; $i < count($paths); $i++) {
+        // Contains the full path to the file
+        $filePath = BASEPATH . $paths[$i] . DIRECTORY_SEPARATOR . str_replace('\\', '/', $class) . '.php';
+        // Require class file if it exists
+        if (file_exists($filePath)) {
+            require_once $filePath;
+        }
+    }
+
+});

--- a/index.php
+++ b/index.php
@@ -1,3 +1,4 @@
+<?php require_once "./autoload.php"; ?>
 <?php require_once "./header.php"; ?>
 <?php require_once "./navbar.php"; ?>
 


### PR DESCRIPTION
Adds an autoloader which can load classes by static defined paths. This allows the autoloader to load classes inside subdirectories even without psr-4 namespaces. If namespaces will be implemented for every class in the future, a psr-4 approach would be more appropriate.