### PR TITLE
Issue#83 - Return executed query statement instead of the fetchAll() result.

### DIFF
--- a/Classes/Database.php
+++ b/Classes/Database.php
@@ -51,13 +51,11 @@ class Database
             }
 
             $stmt->execute($paramsNew);
-            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            $stmt = null;
 
         } catch (PDOExeption $e) {
             die('Database error: ' . $e->getMessage());
         }
-        return $result;
+        return $stmt;
     }
 
 


### PR DESCRIPTION
This allows the usage of things like rowCount() outside of the database class. This makes the database class much more flexible.

**Affected implementations of this change will be only Select-Queries. If a Select-Query exist and depends on the fetchAll() method, then fetchAll() needs to be called extra on the return of the executeQuery() method.**